### PR TITLE
Include shared drive files as crawl targets

### DIFF
--- a/src/main/java/org/codelibs/fess/ds/gsuite/GSuiteClient.java
+++ b/src/main/java/org/codelibs/fess/ds/gsuite/GSuiteClient.java
@@ -155,6 +155,10 @@ public class GSuiteClient implements AutoCloseable {
                 if (StringUtil.isNotBlank(corpora)) {
                     list.setCorpora(corpora);
                 }
+                if (corpora == "allDrives") {
+                    list.setIncludeTeamDriveItems(true);
+                    list.setSupportsTeamDrives(true);
+                }
                 if (StringUtil.isNotBlank(spaces)) {
                     list.setSpaces(spaces);
                 }

--- a/src/main/java/org/codelibs/fess/ds/gsuite/GoogleDriveDataStore.java
+++ b/src/main/java/org/codelibs/fess/ds/gsuite/GoogleDriveDataStore.java
@@ -130,6 +130,7 @@ public class GoogleDriveDataStore extends AbstractDataStore {
 
     // other
     protected static final String FILE_FIELDS = "*";
+    protected static final String FILE_CORPORA = "allDrives";
 
     @Override
     protected String getName() {
@@ -210,7 +211,7 @@ public class GoogleDriveDataStore extends AbstractDataStore {
             final Map<String, String> paramMap, final Map<String, String> scriptMap, final Map<String, Object> defaultDataMap,
             final GSuiteClient client) {
         final String query = paramMap.get("query");
-        final String corpora = paramMap.get("corpora");
+        final String corpora = paramMap.getOrDefault("corpora", FILE_CORPORA);
         final String spaces = paramMap.get("spaces");
         final String fields = paramMap.getOrDefault("fields", FILE_FIELDS);
         final ExecutorService executorService = newFixedThreadPool(Integer.parseInt(paramMap.getOrDefault(NUMBER_OF_THREADS, "1")));


### PR DESCRIPTION
Now, this plugin cannot get a file list of [shared drive](https://support.google.com/drive/answer/7286514?hl=en). This is because the plugin doesn't set several parameters for 'Drive.Files.List' method call.
Reference: [specification of Google Drive API](https://developers.google.com/resources/api-libraries/documentation/drive/v3/java/latest/com/google/api/services/drive/Drive.Files.List.html)

This PR enables to crawl them with setting corpora as `allDrives`, using `list.setIncludeTeamDriveItems(true);` and `list.setSupportsTeamDrives(true)`.

Notice: Google plans to change the specification of files.list API. After the modification, we don't need to set these parameter. Thus, this implementation will be redundant in the future.
Reference: https://developers.google.com/drive/api/v3/reference/files/list