### PR TITLE
chore: update parent POM version to 15.5.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -14,7 +14,7 @@
 	<parent>
 		<groupId>org.codelibs.fess</groupId>
 		<artifactId>fess-parent</artifactId>
-		<version>15.5.0-SNAPSHOT</version>
+		<version>15.5.0</version>
 		<relativePath />
 	</parent>
 	<properties>


### PR DESCRIPTION
## Summary
Update the parent POM version from `15.5.0-SNAPSHOT` to `15.5.0` for release preparation.

## Changes Made
- Updated `fess-parent` version in `pom.xml` from `15.5.0-SNAPSHOT` to `15.5.0`

## Breaking Changes
- None