### PR TITLE
fix: mask access token in debug log

### DIFF
--- a/src/main/java/org/codelibs/fess/ds/gsuite/GSuiteClient.java
+++ b/src/main/java/org/codelibs/fess/ds/gsuite/GSuiteClient.java
@@ -423,7 +423,11 @@ public class GSuiteClient implements AutoCloseable {
                     final TokenResponse token = mapper.readValue(response.getContent(), TokenResponse.class);
 
                     if (logger.isDebugEnabled()) {
-                        logger.debug("Update: {} -> {}", accessToken, token.getAccessToken());
+                        final String newToken = token.getAccessToken();
+                        logger.debug("Update: ***{} -> ***{}",
+                                accessToken != null ? accessToken.substring(accessToken.length() - Math.min(4, accessToken.length()))
+                                        : "null",
+                                newToken != null ? newToken.substring(newToken.length() - Math.min(4, newToken.length())) : "null");
                     }
                     accessToken = token.getAccessToken();
                 } finally {


### PR DESCRIPTION
## Summary
- Fix debug log exposing full access tokens during token refresh
- Mask tokens to show only the last 4 characters in `***xxxx` format
- Safely handle null tokens

## Test plan
- [ ] Verify token refresh works correctly with debug logging enabled
- [ ] Confirm full tokens are no longer exposed in log output

🤖 Generated with [Claude Code](https://claude.com/claude-code)